### PR TITLE
Better version handling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     implementation 'org.bstats:bstats-bukkit:3.0.2'
     compileOnly 'com.google.code.gson:gson:2.10.1'
     compileOnly 'org.spigotmc:spigot-api:1.20.1-R0.1-SNAPSHOT'
-    compileOnly 'com.viaversion:viaversion-api:4.7.0'
+    compileOnly 'com.viaversion:viaversion-api:4.10.0'
 }
 
 compileJava {

--- a/src/main/java/com/artillexstudios/axsmithing/listener/InteractListener.java
+++ b/src/main/java/com/artillexstudios/axsmithing/listener/InteractListener.java
@@ -25,11 +25,11 @@ public class InteractListener implements Listener {
         if (!AxSmithingPlugin.getConfiguration().getBoolean("listen-to-interact-event")) return;
 
         if (AxSmithingPlugin.is1_20()) {
-            if (Via.getAPI().getPlayerVersion(event.getPlayer()) >= Version.v1_20_1.protocolId && !AxSmithingPlugin.getConfiguration().getBoolean("menu.1_20.force-for-1_20-clients")) {
+            if (Via.getAPI().getPlayerVersion(event.getPlayer()) >= 762 && !AxSmithingPlugin.getConfiguration().getBoolean("menu.1_20.force-for-1_20-clients")) {
                 return;
             }
         } else {
-            if (Via.getAPI().getPlayerVersion(event.getPlayer()) != Version.v1_20_1.protocolId && Via.getAPI().getPlayerVersion(event.getPlayer()) != Version.v1_20_2.protocolId) {
+            if (!AxSmithingPlugin.getConfiguration().getBoolean("menu.1_16.force")) {
                 return;
             }
         }
@@ -46,11 +46,11 @@ public class InteractListener implements Listener {
         if (event.getInventory().getType() != InventoryType.SMITHING) return;
 
         if (AxSmithingPlugin.is1_20()) {
-            if (Via.getAPI().getPlayerVersion(event.getPlayer()) >= Version.v1_20_1.protocolId && !AxSmithingPlugin.getConfiguration().getBoolean("menu.1_20.force-for-1_20-clients")) {
+            if (Via.getAPI().getPlayerVersion(event.getPlayer()) >= 762 && !AxSmithingPlugin.getConfiguration().getBoolean("menu.1_20.force-for-1_20-clients")) {
                 return;
             }
         } else {
-            if (Via.getAPI().getPlayerVersion(event.getPlayer()) != Version.v1_20_1.protocolId && Via.getAPI().getPlayerVersion(event.getPlayer()) != Version.v1_20_2.protocolId) {
+            if (!AxSmithingPlugin.getConfiguration().getBoolean("menu.1_16.force")) {
                 return;
             }
         }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -32,6 +32,7 @@ menu:
     upgrade-slot: 12
     output-slot: 14
     dont-convert-with-modeldata: false
+    force: false
     items:
       '1':
         slots:


### PR DESCRIPTION
There's no need to enforce the GUI when it is already supported by ViaBackwards.
https://github.com/ViaVersion/Mappings/blob/48f143edb068713237e2720ce35e4227c60722f9/mappings/diff/mapping-1.16to1.15.json#L5903
https://github.com/ViaVersion/Mappings/blob/48f143edb068713237e2720ce35e4227c60722f9/mappings/diff/mapping-1.19.4to1.20.json#L65

Additionally, the 1.20.4 client can support both 1.16 and 1.20 GUIs.